### PR TITLE
Set default parameter

### DIFF
--- a/src/groupme/groups.php
+++ b/src/groupme/groups.php
@@ -13,7 +13,7 @@ class groups extends client {
 	 * @return string $return
 	 * 
 	 */
-	public function index($args){
+	public function index($args = array()){
 		$params = array(
 			'url' => '/groups',
 			'method' => 'GET',


### PR DESCRIPTION
Appears that `array_merge` in `buildQueryString` would not function if `$args` is not set to an array, especially on a call to `index()` with no arguments